### PR TITLE
Use `if let Err` for chunk upload retry path

### DIFF
--- a/crates/api/lunchmoney/src/upload_service.rs
+++ b/crates/api/lunchmoney/src/upload_service.rs
@@ -58,7 +58,7 @@ impl LunchMoneyTransactionsUploadService for DefaultLunchMoneyTransactionsUpload
                 .context_with(|| format!("Failed chunk: {:?}", chunk));
 
             // https://discord.com/channels/842337014556262411/1134594318414389258/1474122871784869968
-            if chunk_insert_result.is_err() {
+            if let Err(error) = chunk_insert_result {
                 info!(
                     "Insert chunk {}/{} failed ({} transactions); retrying one by one for account '{}'",
                     chunk_index + 1,
@@ -67,7 +67,7 @@ impl LunchMoneyTransactionsUploadService for DefaultLunchMoneyTransactionsUpload
                     account_name
                 );
 
-                warn!("Error inserting chunk: {:?}", chunk_insert_result.err());
+                warn!("Error inserting chunk: {:?}", error);
 
                 for transaction in chunk {
                     api_client


### PR DESCRIPTION
### Motivation
- Make the upload retry branch in the Lunch Money upload service more idiomatic by avoiding `is_err()` + `err()` and binding the error directly.

### Description
- Rewrote the chunk-failure branch in `crates/api/lunchmoney/src/upload_service.rs` to use `if let Err(error) = chunk_insert_result` and switched the `warn!` log to print the bound `error` instead of calling `err()` on the `Result`.

### Testing
- Ran `just fmt` which failed in this environment because `mise install` could not download pinned tools due to outbound tunnel/proxy restrictions. 
- Ran `cargo fmt --all` which failed because the `rustfmt` component could not be downloaded for the same network restrictions. 
- Ran `cargo test -p finance_as_code_api_lunchmoney` which builds successfully; the upload-service unit tests for the changed code passed while several unrelated API-client tests failed with `403 Forbidden` responses due to the environment's proxy, not the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a09fdec088333ae69523ee3783117)