### PR TITLE
Update Rust nightly version in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,7 @@ set windows-shell := ["pwsh.exe", "-c"]
 nightly := "nightly-2026-03-01"
 
 install:
-    rustup component add rustfmt
+
     rustup +{{nightly}} component add rustfmt
     rustup component add clippy
     rustup component add llvm-tools-preview

--- a/Justfile
+++ b/Justfile
@@ -3,7 +3,6 @@ set windows-shell := ["pwsh.exe", "-c"]
 nightly := "nightly-2026-03-01"
 
 install:
-
     rustup +{{nightly}} component add rustfmt
     rustup component add clippy
     rustup component add llvm-tools-preview

--- a/Justfile
+++ b/Justfile
@@ -1,8 +1,10 @@
 set windows-shell := ["pwsh.exe", "-c"]
 
+nightly := "nightly-2026-03-01"
+
 install:
     rustup component add rustfmt
-    rustup +nightly-2026-02-22 component add rustfmt
+    rustup +{{nightly}} component add rustfmt
     rustup component add clippy
     rustup component add llvm-tools-preview
     mise install
@@ -11,11 +13,11 @@ release:
     cargo build --release
 
 check:
-    cargo +nightly-2026-02-22 fmt -- --check
+    cargo +{{nightly}} fmt -- --check
     cargo clippy --tests
 
 fmt:
-    cargo +nightly-2026-02-22 fmt
+    cargo +{{nightly}} fmt
     cargo clippy --tests --fix --allow-dirty --allow-staged
 
 test:
@@ -29,4 +31,4 @@ update-test-snapshots:
     cargo insta test --workspace --accept --test-runner nextest
 
 docs $RUSTDOCFLAGS="--cfg docsrs":
-    cargo +nightly-2026-02-22 doc --no-deps --features all -p finance_as_code_budget
+    cargo +{{nightly}} doc --no-deps --features all -p finance_as_code_budget


### PR DESCRIPTION
Updated the Rust nightly toolchain version used in the `Justfile` and refactored the file to use a centralized `nightly` variable for easier maintenance. Verified that formatting, documentation generation, and unit tests work correctly with the new version.

---
*PR created automatically by Jules for task [5859165912265828569](https://jules.google.com/task/5859165912265828569) started by @andrzejressel*