### PR TITLE
Update Rust nightly version in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set windows-shell := ["pwsh.exe", "-c"]
 
-nightly := "nightly-2026-03-01"
+nightly := "nightly-2026-03-08"
 
 install:
     rustup +{{nightly}} component add rustfmt


### PR DESCRIPTION
This change updates the pinned Rust nightly version used in the project's `Justfile`. This ensures that developer and CI workflows use a more recent version of the nightly toolchain for formatting, linting, and documentation. The update was verified by running all relevant tasks and confirming that they complete without errors.

---
*PR created automatically by Jules for task [5386702744478411719](https://jules.google.com/task/5386702744478411719) started by @andrzejressel*