### PR TITLE
Remove unused dependencies across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,6 @@ dependencies = [
  "finance_as_code_utils_resilience",
  "googletest",
  "httpmock",
- "log",
  "mockall",
  "reqwest 0.13.2",
  "rootcause",
@@ -1476,7 +1475,6 @@ dependencies = [
  "googletest",
  "mlua",
  "mockall",
- "rootcause",
  "rusty-money",
  "uuid",
 ]

--- a/crates/api/actual/Cargo.toml
+++ b/crates/api/actual/Cargo.toml
@@ -12,7 +12,6 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 rootcause.workspace = true
-log.workspace = true
 mockall.workspace = true
 finance_as_code_utils_resilience.workspace = true
 

--- a/crates/budget/root/Cargo.toml
+++ b/crates/budget/root/Cargo.toml
@@ -3,6 +3,9 @@ name = "finance_as_code_budget"
 version = "0.1.0"
 edition = "2024"
 
+[package.metadata.cargo-machete]
+ignored = ["duckdb", "chrono", "finance_as_code_utils_hmap", "uuid", "rusty-money"]
+
 [features]
 source_lunchflow = ["dep:finance_as_code_budget_source_lunchflow"]
 source_mbank = ["dep:finance_as_code_budget_source_mbank"]

--- a/crates/budget/transformer/lua/Cargo.toml
+++ b/crates/budget/transformer/lua/Cargo.toml
@@ -10,12 +10,11 @@ mock = ["mockall"]
 [dependencies]
 finance_as_code_budget_core.workspace = true
 mlua.workspace = true
-rootcause.workspace = true
 uuid.workspace = true
-finance_as_code_utils_hmap.workspace = true
 mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
+finance_as_code_utils_hmap.workspace = true
 googletest.workspace = true
 chrono.workspace = true
 rusty-money.workspace = true

--- a/setup/github/Cargo.toml
+++ b/setup/github/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["bon", "pulumi_gestalt_build"]
+
 [dependencies]
 anyhow.workspace = true
 bon.workspace = true


### PR DESCRIPTION
I have identified and removed unused dependencies across the workspace.

Specifically:
- Removed `log` from `crates/api/actual/Cargo.toml`.
- Removed `rootcause` from `crates/budget/transformer/lua/Cargo.toml`.
- Moved `finance_as_code_utils_hmap` from `dependencies` to `dev-dependencies` in `crates/budget/transformer/lua/Cargo.toml` as it is only used in documentation tests.
- Configured `cargo-machete` to ignore known false positives (dependencies used in macros, build scripts, or documentation tests) in `setup/github/Cargo.toml` and `crates/budget/root/Cargo.toml`.

All workspace tests (excluding those requiring the Pulumi CLI) pass.

---
*PR created automatically by Jules for task [11241358350117211884](https://jules.google.com/task/11241358350117211884) started by @andrzejressel*