### PR TITLE
Update Rust nightly version in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set windows-shell := ["pwsh.exe", "-c"]
 
-nightly := "nightly-2026-03-08"
+nightly := "nightly-2026-03-15"
 
 install:
     rustup +{{nightly}} component add rustfmt


### PR DESCRIPTION
Updated the `nightly` variable in the `Justfile` from `nightly-2026-03-08` to `nightly-2026-03-15`. This change ensures that all project commands using the nightly toolchain (formatting, documentation generation, etc.) use the latest specified version. Verification included running `cargo fmt`, `cargo clippy`, and unit tests across the workspace.

---
*PR created automatically by Jules for task [14669544011500844035](https://jules.google.com/task/14669544011500844035) started by @andrzejressel*