### PR TITLE
Remove unused dependencies across workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,6 @@ dependencies = [
  "finance_as_code_utils_resilience",
  "googletest",
  "httpmock",
- "log",
  "mockall",
  "reqwest 0.13.2",
  "rootcause",

--- a/crates/api/actual/Cargo.toml
+++ b/crates/api/actual/Cargo.toml
@@ -12,7 +12,6 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 rootcause.workspace = true
-log.workspace = true
 mockall.workspace = true
 finance_as_code_utils_resilience.workspace = true
 

--- a/crates/budget/root/Cargo.toml
+++ b/crates/budget/root/Cargo.toml
@@ -14,6 +14,15 @@ all = ["sink_lunchmoney", "source_lunchflow", "source_mbank", "sink_treeline"]
 bundled_db = ["dep:duckdb"]
 all_with_db = ["all", "bundled_db"]
 
+[package.metadata.cargo-machete]
+ignored = [
+    "chrono",
+    "duckdb",
+    "finance_as_code_utils_hmap",
+    "rusty-money",
+    "uuid",
+]
+
 [dependencies]
 finance_as_code_budget_core.workspace = true
 finance_as_code_budget_source_lunchflow = { workspace = true, optional = true }

--- a/crates/budget/transformer/lua/Cargo.toml
+++ b/crates/budget/transformer/lua/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 [features]
 mock = ["mockall"]
 
+[package.metadata.cargo-machete]
+ignored = ["finance_as_code_utils_hmap", "mockall"]
+
 [dependencies]
 finance_as_code_budget_core.workspace = true
 mlua.workspace = true
@@ -16,6 +19,7 @@ finance_as_code_utils_hmap.workspace = true
 mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
+mockall.workspace = true
 googletest.workspace = true
 chrono.workspace = true
 rusty-money.workspace = true

--- a/setup/github/Cargo.toml
+++ b/setup/github/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["bon", "pulumi_gestalt_build"]
+
 [dependencies]
 anyhow.workspace = true
 bon.workspace = true


### PR DESCRIPTION
Removed truly unused dependencies (e.g. `log` in `crates/api/actual`) and added false positives to `[package.metadata.cargo-machete]` ignore lists. Fixed a build error in `crates/budget/transformer/lua` caused by an over-zealous removal and a missing `dev-dependency`. Verified all changes with a subset of relevant tests and tool checks.

---
*PR created automatically by Jules for task [13505369342142429119](https://jules.google.com/task/13505369342142429119) started by @andrzejressel*