### PR TITLE
Cleanup unused dependencies in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,6 @@ dependencies = [
  "finance_as_code_utils_resilience",
  "googletest",
  "httpmock",
- "log",
  "mockall",
  "reqwest 0.13.2",
  "rootcause",
@@ -1481,7 +1480,6 @@ dependencies = [
  "googletest",
  "mlua",
  "mockall",
- "rootcause",
  "rusty-money",
  "uuid",
 ]

--- a/crates/api/actual/Cargo.toml
+++ b/crates/api/actual/Cargo.toml
@@ -12,7 +12,6 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 rootcause.workspace = true
-log.workspace = true
 mockall.workspace = true
 finance_as_code_utils_resilience.workspace = true
 

--- a/crates/budget/root/Cargo.toml
+++ b/crates/budget/root/Cargo.toml
@@ -3,6 +3,9 @@ name = "finance_as_code_budget"
 version = "0.1.0"
 edition = "2024"
 
+[package.metadata.cargo-machete]
+ignored = ["chrono", "duckdb", "finance_as_code_utils_hmap", "rusty-money", "uuid"]
+
 [features]
 source_lunchflow = ["dep:finance_as_code_budget_source_lunchflow"]
 source_mbank = ["dep:finance_as_code_budget_source_mbank"]

--- a/crates/budget/transformer/lua/Cargo.toml
+++ b/crates/budget/transformer/lua/Cargo.toml
@@ -4,13 +4,15 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["finance_as_code_utils_hmap", "mockall"]
+
 [features]
 mock = ["mockall"]
 
 [dependencies]
 finance_as_code_budget_core.workspace = true
 mlua.workspace = true
-rootcause.workspace = true
 uuid.workspace = true
 finance_as_code_utils_hmap.workspace = true
 mockall = { workspace = true, optional = true }

--- a/setup/github/Cargo.toml
+++ b/setup/github/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["bon", "pulumi_gestalt_build"]
+
 [dependencies]
 anyhow.workspace = true
 bon.workspace = true


### PR DESCRIPTION
This PR cleans up unused dependencies in the workspace Cargo.toml files. It also adds metadata for cargo-machete to ignore dependencies that are used in ways the tool cannot detect (e.g., in documentation tests via include_str!, in build scripts, or in generated code). Verified all tests pass.

---
*PR created automatically by Jules for task [6117179375555471934](https://jules.google.com/task/6117179375555471934) started by @andrzejressel*