### PR TITLE
Update Rust nightly version in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set windows-shell := ["pwsh.exe", "-c"]
 
-nightly := "nightly-2026-03-15"
+nightly := "nightly-2026-03-29"
 
 install:
     rustup +{{nightly}} component add rustfmt


### PR DESCRIPTION
Updated the centralized `nightly` variable in the root `Justfile` to `nightly-2026-03-29`. Confirmed that the new toolchain version is correctly used by `just fmt`, `just check`, and `just test` recipes and that the codebase remains compliant with formatting and linting rules.

---
*PR created automatically by Jules for task [2026559063771501924](https://jules.google.com/task/2026559063771501924) started by @andrzejressel*