### PR TITLE
Remove unused dependencies from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,6 @@ dependencies = [
  "finance_as_code_utils_resilience",
  "googletest",
  "httpmock",
- "log",
  "mockall",
  "reqwest 0.13.2",
  "rootcause",
@@ -1480,7 +1479,6 @@ dependencies = [
  "googletest",
  "mlua",
  "mockall",
- "rootcause",
  "rusty-money",
  "uuid",
 ]

--- a/crates/api/actual/Cargo.toml
+++ b/crates/api/actual/Cargo.toml
@@ -12,7 +12,6 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 rootcause.workspace = true
-log.workspace = true
 mockall.workspace = true
 finance_as_code_utils_resilience.workspace = true
 

--- a/crates/budget/root/Cargo.toml
+++ b/crates/budget/root/Cargo.toml
@@ -24,6 +24,9 @@ finance_as_code_budget_transformer_lua.workspace = true
 finance_as_code_budget_transformer_ai_lua.workspace = true
 duckdb = { workspace = true, optional = true, features = ["bundled"] }
 
+[package.metadata.cargo-machete]
+ignored = ["chrono", "duckdb", "finance_as_code_utils_hmap", "rusty-money", "uuid"]
+
 [dev-dependencies]
 rusty-money.workspace = true
 chrono.workspace = true

--- a/crates/budget/transformer/lua/Cargo.toml
+++ b/crates/budget/transformer/lua/Cargo.toml
@@ -10,10 +10,12 @@ mock = ["mockall"]
 [dependencies]
 finance_as_code_budget_core.workspace = true
 mlua.workspace = true
-rootcause.workspace = true
 uuid.workspace = true
 finance_as_code_utils_hmap.workspace = true
 mockall = { workspace = true, optional = true }
+
+[package.metadata.cargo-machete]
+ignored = ["finance_as_code_utils_hmap"]
 
 [dev-dependencies]
 googletest.workspace = true

--- a/setup/github/Cargo.toml
+++ b/setup/github/Cargo.toml
@@ -14,3 +14,6 @@ itertools.workspace = true
 
 [build-dependencies]
 pulumi_gestalt_build.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["bon", "pulumi_gestalt_build"]


### PR DESCRIPTION
This PR cleans up the workspace's dependency tree by removing truly unused crates and marking known false positives (e.g., dependencies used in build scripts or documentation) for `cargo-machete` to ignore.

Key changes:
- `crates/api/actual/Cargo.toml`: Removed `log`.
- `crates/budget/transformer/lua/Cargo.toml`: Removed `rootcause` and ignored `finance_as_code_utils_hmap`.
- `crates/budget/root/Cargo.toml`: Ignored several dependencies used only in doc tests.
- `setup/github/Cargo.toml`: Ignored `bon` and `pulumi_gestalt_build`.
- `Cargo.lock`: Updated manifest hashes and removed dependencies.

---
*PR created automatically by Jules for task [7848314729050751150](https://jules.google.com/task/7848314729050751150) started by @andrzejressel*