### PR TITLE
Update Rust nightly version in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set windows-shell := ["pwsh.exe", "-c"]
 
-nightly := "nightly-2026-03-29"
+nightly := "nightly-2026-04-05"
 
 install:
     rustup +{{nightly}} component add rustfmt


### PR DESCRIPTION
Updates the Rust nightly version used in the project's `Justfile`. The version is changed from `nightly-2026-03-29` to `nightly-2026-04-05`. Verified the updated toolchain with standard project tasks (`fmt`, `check`, `test`).

---
*PR created automatically by Jules for task [15333203198394793358](https://jules.google.com/task/15333203198394793358) started by @andrzejressel*