### PR TITLE
Remove unused dependencies and add cargo-machete ignore lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,6 @@ dependencies = [
  "finance_as_code_utils_resilience",
  "googletest",
  "httpmock",
- "log",
  "mockall",
  "reqwest 0.13.2",
  "rootcause",
@@ -1480,7 +1479,6 @@ dependencies = [
  "googletest",
  "mlua",
  "mockall",
- "rootcause",
  "rusty-money",
  "uuid",
 ]

--- a/crates/api/actual/Cargo.toml
+++ b/crates/api/actual/Cargo.toml
@@ -12,7 +12,6 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 rootcause.workspace = true
-log.workspace = true
 mockall.workspace = true
 finance_as_code_utils_resilience.workspace = true
 

--- a/crates/budget/root/Cargo.toml
+++ b/crates/budget/root/Cargo.toml
@@ -3,6 +3,9 @@ name = "finance_as_code_budget"
 version = "0.1.0"
 edition = "2024"
 
+[package.metadata.cargo-machete]
+ignored = ["chrono", "duckdb", "finance_as_code_utils_hmap", "rusty-money", "uuid"]
+
 [features]
 source_lunchflow = ["dep:finance_as_code_budget_source_lunchflow"]
 source_mbank = ["dep:finance_as_code_budget_source_mbank"]

--- a/crates/budget/transformer/lua/Cargo.toml
+++ b/crates/budget/transformer/lua/Cargo.toml
@@ -4,13 +4,15 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["finance_as_code_utils_hmap"]
+
 [features]
 mock = ["mockall"]
 
 [dependencies]
 finance_as_code_budget_core.workspace = true
 mlua.workspace = true
-rootcause.workspace = true
 uuid.workspace = true
 finance_as_code_utils_hmap.workspace = true
 mockall = { workspace = true, optional = true }

--- a/setup/github/Cargo.toml
+++ b/setup/github/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.cargo-machete]
+ignored = ["bon", "pulumi_gestalt_build"]
+
 [dependencies]
 anyhow.workspace = true
 bon.workspace = true


### PR DESCRIPTION
I have identified and removed unused dependencies across the workspace. For dependencies that were incorrectly flagged as unused by `cargo-machete` (typically due to being used in documentation tests or re-exported in the public API), I added them to the `[package.metadata.cargo-machete].ignored` list in the respective `Cargo.toml` files.

Specifically:
- `log` was removed from `crates/api/actual`.
- `rootcause` was removed from `crates/budget/transformer/lua`.
- `chrono`, `duckdb`, `finance_as_code_utils_hmap`, `rusty-money`, and `uuid` were ignored in `crates/budget/root`.
- `bon` and `pulumi_gestalt_build` were ignored in `setup/github`.
- `finance_as_code_utils_hmap` was ignored in `crates/budget/transformer/lua`.

All changes were verified with `cargo machete --with-metadata` and relevant tests pass.

---
*PR created automatically by Jules for task [8694613482969055674](https://jules.google.com/task/8694613482969055674) started by @andrzejressel*