### PR TITLE
Update Rust nightly version in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set windows-shell := ["pwsh.exe", "-c"]
 
-nightly := "nightly-2026-04-05"
+nightly := "nightly-2026-04-12"
 
 install:
     rustup +{{nightly}} component add rustfmt


### PR DESCRIPTION
I have updated the Rust nightly version used for formatting and documentation in the `Justfile` from `nightly-2026-04-05` to `nightly-2026-04-12`. 

Verification steps taken:
- Verified that the `nightly-2026-04-12` toolchain is available and includes the `rustfmt` component.
- Ran `cargo +nightly-2026-04-12 fmt -- --check` to ensure compatibility.
- Executed the workspace test suite and verified that documentation tests pass when all features are enabled.
- Confirmed that existing code remains compliant with the updated toolchain's formatting rules.

---
*PR created automatically by Jules for task [5963603426613635660](https://jules.google.com/task/5963603426613635660) started by @andrzejressel*