### PR TITLE
Remove unused dependencies and ignore false positives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,6 @@ dependencies = [
  "finance_as_code_utils_resilience",
  "googletest",
  "httpmock",
- "log",
  "mockall",
  "reqwest 0.13.2",
  "rootcause",
@@ -1480,7 +1479,6 @@ dependencies = [
  "googletest",
  "mlua",
  "mockall",
- "rootcause",
  "rusty-money",
  "uuid",
 ]

--- a/crates/api/actual/Cargo.toml
+++ b/crates/api/actual/Cargo.toml
@@ -12,7 +12,6 @@ serde.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 rootcause.workspace = true
-log.workspace = true
 mockall.workspace = true
 finance_as_code_utils_resilience.workspace = true
 

--- a/crates/budget/root/Cargo.toml
+++ b/crates/budget/root/Cargo.toml
@@ -29,3 +29,6 @@ rusty-money.workspace = true
 chrono.workspace = true
 finance_as_code_utils_hmap.workspace = true
 uuid.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["chrono", "duckdb", "finance_as_code_utils_hmap", "rusty-money", "uuid"]

--- a/crates/budget/transformer/lua/Cargo.toml
+++ b/crates/budget/transformer/lua/Cargo.toml
@@ -10,12 +10,14 @@ mock = ["mockall"]
 [dependencies]
 finance_as_code_budget_core.workspace = true
 mlua.workspace = true
-rootcause.workspace = true
 uuid.workspace = true
-finance_as_code_utils_hmap.workspace = true
 mockall = { workspace = true, optional = true }
 
+[package.metadata.cargo-machete]
+ignored = ["finance_as_code_utils_hmap"]
+
 [dev-dependencies]
+finance_as_code_utils_hmap.workspace = true
 googletest.workspace = true
 chrono.workspace = true
 rusty-money.workspace = true

--- a/setup/github/Cargo.toml
+++ b/setup/github/Cargo.toml
@@ -14,3 +14,6 @@ itertools.workspace = true
 
 [build-dependencies]
 pulumi_gestalt_build.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["bon", "pulumi_gestalt_build"]


### PR DESCRIPTION
This PR cleans up unused dependencies across the workspace as identified by `cargo-machete`. It also configures `cargo-machete` to ignore false positives arising from dependencies used in build scripts, code generation via macros, or documentation tests. Documentation tests in `crates/budget/transformer/lua` were fixed by moving the necessary `finance_as_code_utils_hmap` dependency to `dev-dependencies`.

---
*PR created automatically by Jules for task [1053423910112564046](https://jules.google.com/task/1053423910112564046) started by @andrzejressel*