### PR TITLE
Update Rust nightly version in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,6 @@
 set windows-shell := ["pwsh.exe", "-c"]
 
-nightly := "nightly-2026-04-05"
+nightly := "nightly-2026-04-19"
 
 install:
     rustup +{{nightly}} component add rustfmt


### PR DESCRIPTION
This PR updates the pinned Rust nightly version in the `Justfile` from `nightly-2026-04-05` to `nightly-2026-04-19`.

Steps taken:
1. Updated `Justfile`.
2. Installed the new toolchain components via `just install`.
3. Verified formatting with `just fmt`.
4. Ran the full workspace test suite (including doc tests) with `just test`. All tests passed.

---
*PR created automatically by Jules for task [13590867681218342022](https://jules.google.com/task/13590867681218342022) started by @andrzejressel*